### PR TITLE
Change how an Entry is referenced from votes table

### DIFF
--- a/apps/dert_gg/lib/dert_gg/entries/entry.ex
+++ b/apps/dert_gg/lib/dert_gg/entries/entry.ex
@@ -15,7 +15,7 @@ defmodule DertGG.Entries.Entry do
     field :favorite_count, :integer
     field :topic_url, :string
 
-    has_many :votes, DertGG.Votes.Vote, foreign_key: :entry_id
+    has_many :votes, DertGG.Votes.Vote, foreign_key: :entry_id, references: :entry_id
 
     timestamps(type: :utc_datetime)
   end

--- a/apps/dert_gg/lib/dert_gg/entries/entry.ex
+++ b/apps/dert_gg/lib/dert_gg/entries/entry.ex
@@ -15,15 +15,22 @@ defmodule DertGG.Entries.Entry do
     field :favorite_count, :integer
     field :topic_url, :string
 
-    has_many :votes, DertGG.Votes.Vote
+    has_many :votes, DertGG.Votes.Vote, foreign_key: :entry_id, references: :entry_id
 
     timestamps(type: :utc_datetime)
   end
 
   @fields [
-    :author, :author_id, :html_content, :text_content,
-    :entry_id, :entry_timestamp, :entry_updated_at,
-    :entry_created_at, :favorite_count, :topic_url
+    :author,
+    :author_id,
+    :html_content,
+    :text_content,
+    :entry_id,
+    :entry_timestamp,
+    :entry_updated_at,
+    :entry_created_at,
+    :favorite_count,
+    :topic_url
   ]
 
   @required_fields @fields -- [:entry_updated_at]

--- a/apps/dert_gg/lib/dert_gg/entries/entry.ex
+++ b/apps/dert_gg/lib/dert_gg/entries/entry.ex
@@ -15,7 +15,7 @@ defmodule DertGG.Entries.Entry do
     field :favorite_count, :integer
     field :topic_url, :string
 
-    has_many :votes, DertGG.Votes.Vote, foreign_key: :entry_id, references: :entry_id
+    has_many :votes, DertGG.Votes.Vote, foreign_key: :entry_id
 
     timestamps(type: :utc_datetime)
   end

--- a/apps/dert_gg/lib/dert_gg/votes/vote.ex
+++ b/apps/dert_gg/lib/dert_gg/votes/vote.ex
@@ -4,7 +4,7 @@ defmodule DertGG.Votes.Vote do
   use Ecto.Schema
 
   schema "votes" do
-    belongs_to :entry, DertGG.Entries.Entry, references: :entry_id
+    belongs_to :entry, DertGG.Entries.Entry, foreign_key: :entry_id
     belongs_to :account, DertGG.Accounts.Account
 
     timestamps(type: :utc_datetime)

--- a/apps/dert_gg/lib/dert_gg/votes/vote.ex
+++ b/apps/dert_gg/lib/dert_gg/votes/vote.ex
@@ -4,7 +4,7 @@ defmodule DertGG.Votes.Vote do
   use Ecto.Schema
 
   schema "votes" do
-    belongs_to :entry, DertGG.Entries.Entry
+    belongs_to :entry, DertGG.Entries.Entry, references: :entry_id
     belongs_to :account, DertGG.Accounts.Account
 
     timestamps(type: :utc_datetime)

--- a/apps/dert_gg/lib/dert_gg/votes/vote.ex
+++ b/apps/dert_gg/lib/dert_gg/votes/vote.ex
@@ -4,7 +4,7 @@ defmodule DertGG.Votes.Vote do
   use Ecto.Schema
 
   schema "votes" do
-    belongs_to :entry, DertGG.Entries.Entry, foreign_key: :entry_id
+    belongs_to :entry, DertGG.Entries.Entry, foreign_key: :entry_id, references: :entry_id
     belongs_to :account, DertGG.Accounts.Account
 
     timestamps(type: :utc_datetime)

--- a/apps/dert_gg/priv/repo/migrations/20211015215035_create_votes_table.exs
+++ b/apps/dert_gg/priv/repo/migrations/20211015215035_create_votes_table.exs
@@ -3,7 +3,7 @@ defmodule DertGG.Repo.Migrations.CreateVotesTable do
 
   def change do
     create table(:votes) do
-      add :entry_id, references(:entries)
+      add :entry_id, references(:entries, column: :entry_id)
       add :account_id, :integer
 
       timestamps(type: :utc_datetime)


### PR DESCRIPTION
References #1

Votes table now references entries table by `entry_id` instead of `id`, which makes things easier for the users of the API as well as myself.