### PR TITLE
Use PubSub to subscribe and  broadcast to a topic

### DIFF
--- a/apps/dert_gg_web/lib/dert_gg_web/application.ex
+++ b/apps/dert_gg_web/lib/dert_gg_web/application.ex
@@ -7,6 +7,7 @@ defmodule DertGGWeb.Application do
 
   def start(_type, _args) do
     children = [
+      {Phoenix.PubSub, name: DertGGWeb.PubSub},
       # Start the Telemetry supervisor
       DertGGWeb.Telemetry,
       # Start the Endpoint (http/https)

--- a/apps/dert_gg_web/lib/dert_gg_web/controllers/api/vote_controller.ex
+++ b/apps/dert_gg_web/lib/dert_gg_web/controllers/api/vote_controller.ex
@@ -4,6 +4,7 @@ defmodule DertGGWeb.Api.VoteController do
   alias DertGGWeb.Authentication
   alias DertGG.Votes
   alias DertGG.Votes.Vote
+  alias Phoenix.PubSub
 
   def create(conn, params) do
     with account <- Authentication.get_current_account(conn) do

--- a/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.ex
+++ b/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.ex
@@ -1,13 +1,16 @@
 defmodule DertGGWeb.DertsLive do
   use DertGGWeb, :live_view
 
+  alias Phoenix.PubSub
+
   def mount(_params, _session, socket) do
     entries = DertGG.Entries.get_entries()
+    if connected?(socket), do: PubSub.subscribe(DertGGWeb.PubSub, "vote-updates")
 
-    {
-      :ok,
-      socket
-      |> assign(:entries, entries)
-    }
+    {:ok, assign(socket, :entries, entries)}
+  end
+
+  def handle_info(%{entries: entries}, socket) do
+    {:noreply, assign(socket, :entries, entries)}
   end
 end


### PR DESCRIPTION
#9

Using `PubSub` to be able to broadcast a change in top entries so that LiveViews can react to that message and re-render.