### PR TITLE
Implement a function that only returns a subset of entries

### DIFF
--- a/apps/dert_gg/lib/dert_gg/entries.ex
+++ b/apps/dert_gg/lib/dert_gg/entries.ex
@@ -26,6 +26,18 @@ defmodule DertGG.Entries do
 
   def get_entries(), do: Repo.all(from e in Entry, preload: [:votes])
 
+  def get_top_entries(opts \\ [top: 10]) do
+    limit = Keyword.get(opts, :top)
+
+    Entry
+    |> join(:left, [e], v in assoc(e, :votes))
+    |> select([e], %{entry: e, vote_count: count(e.id)})
+    |> group_by([e], e.id)
+    |> order_by([e], desc: count(e.id), desc: e.inserted_at)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
   @doc """
   Creates a entry.
 

--- a/apps/dert_gg/test/dert_gg/entries_test.exs
+++ b/apps/dert_gg/test/dert_gg/entries_test.exs
@@ -73,4 +73,36 @@ defmodule DertGG.EntriesTest do
       end
     end
   end
+
+  describe "get_top_entries/0-1" do
+    test "returns top 10 entries by vote count by default" do
+      entry1 = Factory.insert(:entry)
+      Factory.insert_list(3, :vote, entry: entry1)
+
+      entry2 = Factory.insert(:entry)
+      Factory.insert_list(2, :vote, entry: entry2)
+
+      Factory.insert_list(9, :vote)
+
+      entries = Entries.get_top_entries()
+
+      assert length(entries) == 10
+
+      # First entry is the one with the highest vote count
+      assert [%{entry: ^entry1, vote_count: 3} | _] = entries
+    end
+
+    test "returns the given number of entries by vote count" do
+      entry1 = Factory.insert(:entry)
+      Factory.insert_list(2, :vote, entry: entry1)
+
+      entry2 = Factory.insert(:entry)
+      Factory.insert_list(1, :vote, entry: entry2)
+
+      entries = Entries.get_top_entries(top: 1)
+
+      assert %{entry: entry1, vote_count: 2} in entries
+      refute %{entry: entry2, vote_count: 1} in entries
+    end
+  end
 end

--- a/apps/dert_gg_web/lib/dert_gg_web/controllers/api/vote_controller.ex
+++ b/apps/dert_gg_web/lib/dert_gg_web/controllers/api/vote_controller.ex
@@ -1,9 +1,10 @@
 defmodule DertGGWeb.Api.VoteController do
   use DertGGWeb, :controller
 
-  alias DertGGWeb.Authentication
+  alias DertGG.Entries
   alias DertGG.Votes
   alias DertGG.Votes.Vote
+  alias DertGGWeb.Authentication
   alias Phoenix.PubSub
 
   def create(conn, params) do
@@ -20,6 +21,7 @@ defmodule DertGGWeb.Api.VoteController do
       end
 
       vote_count = Votes.get_count(entry_id)
+      PubSub.broadcast(DertGGWeb.PubSub, "vote-updates", %{entries: Entries.get_top_entries()})
 
       conn
       |> json(%{

--- a/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.ex
+++ b/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.ex
@@ -4,7 +4,7 @@ defmodule DertGGWeb.DertsLive do
   alias Phoenix.PubSub
 
   def mount(_params, _session, socket) do
-    entries = DertGG.Entries.get_entries()
+    entries = DertGG.Entries.get_top_entries()
     if connected?(socket), do: PubSub.subscribe(DertGGWeb.PubSub, "vote-updates")
 
     {:ok, assign(socket, :entries, entries)}

--- a/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.html.heex
+++ b/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.html.heex
@@ -8,12 +8,12 @@
     </tr>
   </thead>
   <tbody>
-    <%= for {entry, index} <- Enum.with_index(@entries, 1) do %>
+    <%= for {%{entry: entry, vote_count: vote_count}, index} <- Enum.with_index(@entries, 1) do %>
       <tr class="table-hover">
         <th scope="row"><%= index %></th>
         <td><%= entry.text_content %></td>
         <td><a href={"https://eksisozluk.com/entry/#{entry.entry_id}"}><%= entry.author %></a></td>
-        <td><%= IO.inspect(length(entry.votes)) %></td>
+        <td><%= vote_count %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
References #10 

Implemented `Entries.get_top_entries/1` which returns a subset of entries ordered by first `vote_count` ascending and then `inserted_at` descending.

Also we broadcast to "vote-updates" topic all the top entries once a vote is either deleted or created.